### PR TITLE
Add max-width to Toast components

### DIFF
--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -65,7 +65,6 @@ keep them from being tree-shaken out.
   max-width: 95svw;
 }
 
-
 @layer base {
   :root {
     font-family: "Fira Sans", sans-serif;


### PR DESCRIPTION
The fixed width was cutoff on small screens. Now limited by the screen's width.

TBH, not sure there's a nicer or more efficient way to do this. I didn't see max-width as a configuration option for the component itself.