### PR TITLE
Modify Podman for macOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -213,7 +213,7 @@ sops *args:
 [working-directory: "./playwright/"]
 [linux]
 start-playwright:
-  podman run --add-host=hostmachine:host-gateway -p 3001:3000 --rm --init -it --workdir /home/pwuser --user pwuser mcr.microsoft.com/playwright:v1.55.0-noble /bin/sh -c "npx -y playwright@1.55.0 run-server --port 3000 --host 0.0.0.0"
+  podman run --add-host=hostmachine:host-gateway -p 3001:3000 --rm --init -it --name playwright-server  --workdir /home/pwuser --user pwuser mcr.microsoft.com/playwright:v1.55.0-noble /bin/sh -c "npx -y playwright@1.55.0 run-server --port 3000 --host 0.0.0.0"
 
 
 # run the Playwright server in a container


### PR DESCRIPTION
Removed the host networking arguments for podman on macOS since it causes issues and doesn't seem to be needed. 

Made the existing option be tagged for linux, and the new one is tagged for macOS using `just`
[attributes](https://github.com/casey/just?tab=readme-ov-file#attributes)